### PR TITLE
Add netherite nugget item and recipes

### DIFF
--- a/src/main/java/com/pedalhat/lategameplus/LateGamePlus.java
+++ b/src/main/java/com/pedalhat/lategameplus/LateGamePlus.java
@@ -2,6 +2,8 @@ package com.pedalhat.lategameplus;
 
 import net.fabricmc.api.ModInitializer;
 
+import com.pedalhat.lategameplus.item.ModItems;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,11 +16,12 @@ public class LateGamePlus implements ModInitializer {
 	public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
 
 	@Override
-	public void onInitialize() {
-		// This code runs as soon as Minecraft is in a mod-load-ready state.
-		// However, some things (like resources) may still be uninitialized.
-		// Proceed with mild caution.
+        public void onInitialize() {
+                // This code runs as soon as Minecraft is in a mod-load-ready state.
+                // However, some things (like resources) may still be uninitialized.
+                // Proceed with mild caution.
 
-		LOGGER.info("Hello Fabric world!");
-	}
+                LOGGER.info("Hello Fabric world!");
+                ModItems.registerModItems();
+        }
 }

--- a/src/main/java/com/pedalhat/lategameplus/item/ModItems.java
+++ b/src/main/java/com/pedalhat/lategameplus/item/ModItems.java
@@ -1,0 +1,23 @@
+package com.pedalhat.lategameplus.item;
+
+import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemGroups;
+import net.minecraft.registry.Registries;
+import net.minecraft.registry.Registry;
+import net.minecraft.util.Identifier;
+
+import com.pedalhat.lategameplus.LateGamePlus;
+
+public class ModItems {
+    public static final Item NETHERITE_NUGGET = registerItem("netherite_nugget", new Item(new Item.Settings()));
+
+    private static Item registerItem(String name, Item item) {
+        return Registry.register(Registries.ITEM, Identifier.of(LateGamePlus.MOD_ID, name), item);
+    }
+
+    public static void registerModItems() {
+        LateGamePlus.LOGGER.info("Registering Mod Items for " + LateGamePlus.MOD_ID);
+        ItemGroupEvents.modifyEntriesEvent(ItemGroups.INGREDIENTS).register(entries -> entries.add(NETHERITE_NUGGET));
+    }
+}

--- a/src/main/resources/assets/lategameplus/lang/en_us.json
+++ b/src/main/resources/assets/lategameplus/lang/en_us.json
@@ -1,0 +1,3 @@
+{
+  "item.lategameplus.netherite_nugget": "Netherite Nugget"
+}

--- a/src/main/resources/assets/lategameplus/lang/es_es.json
+++ b/src/main/resources/assets/lategameplus/lang/es_es.json
@@ -1,0 +1,3 @@
+{
+  "item.lategameplus.netherite_nugget": "Pepita de netherita"
+}

--- a/src/main/resources/assets/lategameplus/models/item/netherite_nugget.json
+++ b/src/main/resources/assets/lategameplus/models/item/netherite_nugget.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:item/netherite_scrap"
+  }
+}

--- a/src/main/resources/data/lategameplus/recipes/netherite_ingot_from_netherite_nugget.json
+++ b/src/main/resources/data/lategameplus/recipes/netherite_ingot_from_netherite_nugget.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "misc",
+  "pattern": [
+    "###",
+    "###",
+    "###"
+  ],
+  "key": {
+    "#": {
+      "item": "lategameplus:netherite_nugget"
+    }
+  },
+  "result": {
+    "item": "minecraft:netherite_ingot"
+  }
+}

--- a/src/main/resources/data/lategameplus/recipes/netherite_nugget.json
+++ b/src/main/resources/data/lategameplus/recipes/netherite_nugget.json
@@ -1,0 +1,11 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "category": "misc",
+  "ingredients": [
+    { "item": "minecraft:netherite_ingot" }
+  ],
+  "result": {
+    "item": "lategameplus:netherite_nugget",
+    "count": 9
+  }
+}


### PR DESCRIPTION
## Summary
- add ModItems class and register netherite nugget
- wire item registration into mod initializer
- provide item model, translations, and two crafting recipes

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689ffa0eb52c83318e96297b7562331d